### PR TITLE
Update style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -58,6 +58,12 @@ body{
 	padding-top: 0;
 }
 
+/* Admin Top Navigation fixes */
+
+body.admin-bar .navbar-fixed-top{ 
+	top: 28px; 
+}
+
 .nav-container{
 	padding-left: 0;
 	padding-right: 0;


### PR DESCRIPTION
Top Navigation Wordpress crash width .navbar class before, so I just change it and work. 

add css
body.admin-bar .navbar-fixed-top { 
top: 28px; 
}

Change .navbar in header.php to  
.navbar{ 
        position: absolute;
}
