### PR TITLE
Highlight the active main nav link item.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -441,7 +441,7 @@ add_editor_style('editor-style.css');
 
 add_filter('nav_menu_css_class', 'add_active_class', 10, 2 );
 function add_active_class($classes, $item) {
-	if(in_array('current-menu-item', $classes)) {
+	if($item->menu_item_parent == 0 && in_array('current-menu-item', $classes)) {
         $classes[] = "active";
 	}
     return $classes;


### PR DESCRIPTION
Adds Twitter Bootstrap's standard "active" class to the current tab.
