### PR TITLE
Add the prefix 'alert-' to 'type' for the alert block and masagge.

### DIFF
--- a/library/shortcodes.php
+++ b/library/shortcodes.php
@@ -69,7 +69,7 @@ function alerts( $atts, $content = null ) {
 	'text' => '', 
 	), $atts ) );
 	
-	$output = '<div class="fade in alert '. $type . '">';
+	$output = '<div class="fade in alert alert-'. $type . '">';
 	if($close == 'true') {
 		$output .= '<a class="close" data-dismiss="alert">×</a>';
 	}
@@ -88,7 +88,7 @@ function block_messages( $atts, $content = null ) {
 	'text' => '', 
 	), $atts ) );
 	
-	$output = '<div class="fade in alert alert-block '. $type . '">';
+	$output = '<div class="fade in alert alert-block alert-'. $type . '">';
 	if($close == 'true') {
 		$output .= '<a class="close" data-dismiss="alert">×</a>';
 	}


### PR DESCRIPTION
Add the prefix 'alert-' to 'type' in the alert block and masagge shortcodes so it can take the correct style from the CSS file 'alert-error', 'alert-warning', etc. when a user adds only the type name as is specified in the website 'type="(warning info success error)"'.
