### PR TITLE
Fixed a typo in meta:viewport

### DIFF
--- a/header.php
+++ b/header.php
@@ -12,7 +12,7 @@
 		
 		<title><?php bloginfo('name'); ?><?php wp_title('-', true, 'left'); ?></title>
 				
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta name="viewport" content="width=device-width; initial-scale=1.0">
 		
 		<!-- icons & favicons -->
 		<!-- For iPhone 4 -->


### PR DESCRIPTION
Chrome marks it as an error and ignores this tag, because of comma
instead of semicolon.
