### PR TITLE
fixed add_homepage_meta_box() 

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -274,7 +274,7 @@ function remove_thumbnail_dimensions( $html ) {
 function add_homepage_meta_box() {  
 	global $post;
 	// Only add homepage meta box if template being used is the homepage template
-	// $post_id = isset($_GET['post']) ? $_GET['post'] : isset($_POST['post_ID']) ? $_POST['post_ID'] : "";
+	// $post_id = isset($_GET['post']) ? $_GET['post'] : (isset($_POST['post_ID']) ? $_POST['post_ID'] : "");
 	$post_id = $post->ID;
 	$template_file = get_post_meta($post_id,'_wp_page_template',TRUE);
 	if ($template_file == 'page-homepage.php')


### PR DESCRIPTION
I originally noticed that there was a notice coming from line 277 whenever you were adding a new post:

```
$post_id = $_GET['post'] ? $_GET['post'] : $_POST['post_ID'];
```

So, I fixed it with a ternary, but then I noticed that the function wasn't working at all, so I added in the call to the global $post variable and now it seems to work.

I left that original line (with my ternary way) in, commented out, in case you guys want it, but it didn't seem like the function had access to the right request variables in the function.

And now, when you select the homepage template, it shows the homepage_meta_box
