### PR TITLE
remove !important on brand color

### DIFF
--- a/style.css
+++ b/style.css
@@ -57,7 +57,7 @@ body.admin-bar .navbar-fixed-top{
 }
 
 .navbar .brand{
-	color: #000 !important;
+	color: #000;
 	text-shadow: 0 1px 0 rgba(255, 255, 255, 0.1), 0 0 30px rgba(255, 255, 255, 0.125);
 	font-weight: bold !important;
 }


### PR DESCRIPTION
The !important on the brand color was forcing a black head title, even when the color has to be changed ( black background for example ) this was a real problem when using some bootswatch theme.
