### PR TITLE
Child theme support

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -475,7 +475,7 @@ if( !function_exists("theme_styles") ) {
         // This is the compiled css file from LESS - this means you compile the LESS file locally and put it in the appropriate directory if you want to make any changes to the master bootstrap.css.
         wp_register_style( 'bootstrap', get_template_directory_uri() . '/library/css/bootstrap.css', array(), '1.0', 'all' );
         wp_register_style( 'bootstrap-responsive', get_template_directory_uri() . '/library/css/responsive.css', array(), '1.0', 'all' );
-        wp_register_style( 'wp-bootstrap', get_template_directory_uri() . '/style.css', array(), '1.0', 'all' );
+        wp_register_style( 'wp-bootstrap', get_stylesheet_uri(), array(), '1.0', 'all' );
         
         wp_enqueue_style( 'bootstrap' );
         wp_enqueue_style( 'bootstrap-responsive' );


### PR DESCRIPTION
I changed how the main stylesheet is loaded to make child themes work.  The way it was working, it would always load the style.css file from the wordpress-bootstrap theme, even for a child theme.  I updated it to use the get_stylesheet_uri() function, which gets the style.css file from the currently active theme.
