### PR TITLE
getting rid of the container-fluid class

### DIFF
--- a/library/css/bootstrap.css
+++ b/library/css/bootstrap.css
@@ -4880,13 +4880,6 @@ blockquote.pull-left {
 		padding-top: 60px;
 	}
 	
-	.container-fluid {
-		max-width: 970px;
-		margin: 0 auto;
-		padding-left: 20px;
-		padding-right: 20px;
-	}
-	
 	#inner-footer {
 		padding: 0;
 	}

--- a/library/less/wp.less
+++ b/library/less/wp.less
@@ -500,13 +500,6 @@ blockquote.pull-left{
 		padding-top: 60px;
 	}
 	
-	.container-fluid{
-		max-width: 970px;
-		margin: 0 auto;
-		padding-left: 20px;
-		padding-right: 20px;
-	}
-	
 	#inner-footer{
 		padding: 0;
 	}


### PR DESCRIPTION
3.0 no longer uses the `.container-fluid` thing, so it can now be removed in the 3.0-wip branch. Closes #119 atm in the 3.0 branch but still open for the master branch.
