### PR TITLE
`register_nav_menus()` automatically takes care of `add_theme_support('menus')`

### DIFF
--- a/library/bones.php
+++ b/library/bones.php
@@ -70,7 +70,6 @@ function bones_theme_support() {
 			'chat'     // chat transcript 
 		)
 	);	
-	add_theme_support( 'menus' );            // wp menus
 	register_nav_menus(                      // wp3+ menus
 		array( 
 			'main_nav' => 'The Main Menu',   // main nav in header


### PR DESCRIPTION
`register_nav_menus()` automatically takes care of
`add_theme_support('menus')`
so this is not needed.

"This function automatically registers custom menu support for the
theme therefore you do not need to call add_theme_support( 'menus' ); "
Soruce: http://codex.wordpress.org/Function_Reference/register_nav_menus
