### PR TITLE
do_action() comment_form fix

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -145,7 +145,7 @@ The comments page for Bones
 	
 	<?php 
 		//comment_form();
-		do_action('comment_form()', $post->ID); 
+		do_action('comment_form', $post->ID); 
 	
 	?>
 	


### PR DESCRIPTION
The brackets break it. The wp-recaptcha plugin works finely now (https://github.com/320press/wordpress-bootstrap/issues/20).
