### PR TITLE
Strict standards requirement for Nav_Walker

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -455,7 +455,7 @@ add_filter( 'the_content', 'first_paragraph' );
          * Note on $depth: Counterintuitively, $depth here means the "depth right before we start this menu".  
          *                   So basically add one to what you'd expect it to be 
          */         
-        function start_lvl(&$output, $depth) 
+        function start_lvl(&$output, $depth = 0, $args = array()) 
         {
             $tabs = str_repeat("\t", $depth); 
             // If we are about to start the first submenu, we need to give it a dropdown-menu class 
@@ -472,7 +472,7 @@ add_filter( 'the_content', 'first_paragraph' );
          * Note on $depth: Counterintuitively, $depth here means the "depth right before we start this menu".  
          *                   So basically add one to what you'd expect it to be 
          */         
-        function end_lvl(&$output, $depth)  
+        function end_lvl(&$output, $depth = 0, $args = array())  
         {
             if ($depth == 0) { // This is actually the end of the level-1 submenu ($depth is misleading here too!) 
  
@@ -487,7 +487,7 @@ add_filter( 'the_content', 'first_paragraph' );
         /* Output the <li> and the containing <a> 
          * Note: $depth is "correct" at this level 
          */         
-        function start_el(&$output, $item, $depth, $args)  
+        function start_el(&$output, $item, $depth = 0, $args = array(), $current_object_id = 0)  
         {    
             global $wp_query; 
             $indent = ( $depth ) ? str_repeat( "\t", $depth ) : ''; 
@@ -538,7 +538,7 @@ add_filter( 'the_content', 'first_paragraph' );
          * Note: the <a> is already closed 
          * Note 2: $depth is "correct" at this level 
          */         
-        function end_el (&$output, $item, $depth, $args)
+        function end_el (&$output, $item, $depth = 0, $args = array())
         {
             $output .= '</li>'; 
             return;


### PR DESCRIPTION
Strict standards require the Nav_Walker subclass to have the same
method declaration prototypes as the superclass, otherwise warnings
pop up and make people sad.
