### PR TITLE
Added dependency to wp_register_style

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -574,8 +574,8 @@ if( !function_exists("theme_styles") ) {
     function theme_styles() { 
         // This is the compiled css file from LESS - this means you compile the LESS file locally and put it in the appropriate directory if you want to make any changes to the master bootstrap.css.
         wp_register_style( 'bootstrap', get_template_directory_uri() . '/library/css/bootstrap.css', array(), '1.0', 'all' );
-        wp_register_style( 'bootstrap-responsive', get_template_directory_uri() . '/library/css/responsive.css', array(), '1.0', 'all' );
-        wp_register_style( 'wp-bootstrap', get_stylesheet_uri(), array(), '1.0', 'all' );
+        wp_register_style( 'bootstrap-responsive', get_template_directory_uri() . '/library/css/responsive.css', array('bootstrap'), '1.0', 'all' );
+        wp_register_style( 'wp-bootstrap', get_stylesheet_uri(), array('bootstrap-responsive'), '1.0', 'all' );
         
         wp_enqueue_style( 'bootstrap' );
         wp_enqueue_style( 'bootstrap-responsive' );


### PR DESCRIPTION
I was having some problems after I registered a style that depended on bootstrap, and I think this fixed it (BTW, I have never submitted a pull-request, so if this is bad form/stupid whatever, please feel free to say so :D...)
