### PR TITLE
Use __() instead of _e()

### DIFF
--- a/index.php
+++ b/index.php
@@ -32,8 +32,8 @@
 					<?php } else { // if it is disabled, display regular wp prev & next links ?>
 						<nav class="wp-prev-next">
 							<ul class="clearfix">
-								<li class="prev-link"><?php next_posts_link(_e('&laquo; Older Entries', "bonestheme")) ?></li>
-								<li class="next-link"><?php previous_posts_link(_e('Newer Entries &raquo;', "bonestheme")) ?></li>
+								<li class="prev-link"><?php next_posts_link(__('&laquo; Older Entries', "bonestheme")) ?></li>
+								<li class="next-link"><?php previous_posts_link(__('Newer Entries &raquo;', "bonestheme")) ?></li>
 							</ul>
 						</nav>
 					<?php } ?>		


### PR DESCRIPTION
The `next_posts_link()` and `previous-posts_link()` want the translated value returned, not output, so we want `__()` instead of `_e()`.
