### PR TITLE
Fix for 1.4+ version of less.

### DIFF
--- a/library/less/variables.less
+++ b/library/less/variables.less
@@ -178,7 +178,7 @@
 // Navbar
 // -------------------------
 @navbarCollapseWidth:             979px;
-@navbarCollapseDesktopWidth:      @navbarCollapseWidth + 1;
+@navbarCollapseDesktopWidth:      (@navbarCollapseWidth + 1);
 
 @navbarHeight:                    40px;
 @navbarBackgroundHighlight:       #ffffff;
@@ -260,7 +260,7 @@
 @popoverTitleBackground:  darken(@popoverBackground, 3%);
 
 // Special enhancement for popovers
-@popoverArrowOuterWidth:  @popoverArrowWidth + 1;
+@popoverArrowOuterWidth:  (@popoverArrowWidth + 1);
 @popoverArrowOuterColor:  rgba(0,0,0,.25);
 
 


### PR DESCRIPTION
Less introduced a new `--strict-math=off` flag. But apparently (less/less.js#1480) this doesn't apply to @media queries. So compiling Bootstrap 2.3.1 on less 1.5.1 will fail.

```
$ git clone git@github.com:320press/wordpress-bootstrap.git
$ cd wordpress-bootstrap/library
$ lessc less/responsive.less > css/responsive.css
$ lessc -v
lessc 1.5.1 (LESS Compiler) [JavaScript]
```

Can't submit fixes for Bootstrap any more, so might as well put this fix in here. It exists in Bootstrap 2.3.1 and 2.3.2.
