### PR TITLE
fix wp_title() so it behaves just like the standard wp themes

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -484,4 +484,30 @@ if( !function_exists( "theme_js" ) ) {
 }
 add_action( 'wp_enqueue_scripts', 'theme_js' );
 
+// Get <head> <title> to behave like other themes
+function wp_bootstrap_wp_title( $title, $sep ) {
+  global $paged, $page;
+
+  if ( is_feed() ) {
+    return $title;
+  }
+
+  // Add the site name.
+  $title .= get_bloginfo( 'name' );
+
+  // Add the site description for the home/front page.
+  $site_description = get_bloginfo( 'description', 'display' );
+  if ( $site_description && ( is_home() || is_front_page() ) ) {
+    $title = "$title $sep $site_description";
+  }
+
+  // Add a page number if necessary.
+  if ( $paged >= 2 || $page >= 2 ) {
+    $title = "$title $sep " . sprintf( __( 'Page %s', 'wpbootstrap' ), max( $paged, $page ) );
+  }
+
+  return $title;
+}
+add_filter( 'wp_title', 'wp_bootstrap_wp_title', 10, 2 );
+
 ?>


### PR DESCRIPTION
this should close my own issue (https://github.com/320press/wordpress-bootstrap/issues/169) while not interfering with other plug-ins or stuff that expects wp_title() to be where it is. there's a similar issue on your wordpress foundation theme (https://github.com/320press/wordpress-foundation/issues/28) that would also be fixed by this patch to functions.php.

thanks for the great work!
