### PR TITLE
Fix header.php for issue #194 IE 8 Display

### DIFF
--- a/header.php
+++ b/header.php
@@ -11,8 +11,13 @@
 		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 		<title><?php wp_title( '|', true, 'right' ); ?></title>	
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-				
-		<!-- media-queries.js (fallback) -->
+  		<link rel="pingback" href="<?php bloginfo('pingback_url'); ?>">
+
+		<!-- wordpress head functions -->
+		<?php wp_head(); ?>
+		<!-- end of wordpress head -->
+		<!-- IE8 fallback moved below head to work properly. Added respond as well. Tested to work. -->
+			<!-- media-queries.js (fallback) -->
 		<!--[if lt IE 9]>
 			<script src="http://css3-mediaqueries-js.googlecode.com/svn/trunk/css3-mediaqueries.js"></script>			
 		<![endif]-->
@@ -20,14 +25,12 @@
 		<!-- html5.js -->
 		<!--[if lt IE 9]>
 			<script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-		<![endif]-->
+		<![endif]-->	
 		
-  		<link rel="pingback" href="<?php bloginfo('pingback_url'); ?>">
-
-		<!-- wordpress head functions -->
-		<?php wp_head(); ?>
-		<!-- end of wordpress head -->
-				
+			<!-- respond.js -->
+		<!--[if lt IE 9]>
+		          <script type='text/javascript' src="http://cdnjs.cloudflare.com/ajax/libs/respond.js/1.4.2/respond.js"></script>
+		<![endif]-->	
 	</head>
 	
 	<body <?php body_class(); ?>>


### PR DESCRIPTION
Fixes broken IE8. Removed to below wp-head and load respond.js (tested to work). For me, respond.js inclusion was necessary.

Respond.js in this setup only works if you use the stylesheets from 320press. Stylesheets on a CDN require additional setup.
