### PR TITLE
Don't show 'comments are closed' on pages that have comments turned off

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -47,18 +47,9 @@ The comments page for Bones
 	  		<li><?php next_comments_link( __("Newer comments","wpbootstrap") ) ?></li>
 		</ul>
 	</nav>
-  
-	<?php else : // this is displayed if there are no comments so far ?>
 
-	<?php if ( comments_open() ) : ?>
-    	<!-- If comments are open, but there are no comments. -->
-
-	<?php else : // comments are closed 
-	?>
-		
-	<!-- If comments are closed. -->
+	<?php if ( ! comments_open() ) : ?>
 	<p class="alert alert-info"><?php _e("Comments are closed","wpbootstrap"); ?>.</p>
-				
 	<?php endif; ?>
 
 <?php endif; ?>


### PR DESCRIPTION
There seems to have been an error in the comment logic in the original import (based on bones).
The upshot is that the 'Comments are closed' message gets displayed even if comments are turned off for a page.
I think the error was that the 'else' at line 51 snuck in. It was indented so it was hard to see that it incorrectly closes off the outer 'if ( have_comments() )'. Aside: +1 for Python's style of indentation.
I've used the twentyfourteen theme as a reference to make this patch.
