### PR TITLE
deprecated callbacks in preg_replace. replace with preg_replace_callback

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -299,10 +299,12 @@ function wp_bootstrap_my_widget_tag_cloud_args( $args ) {
 // filter tag clould output so that it can be styled by CSS
 function wp_bootstrap_add_tag_class( $taglinks ) {
     $tags = explode('</a>', $taglinks);
-    $regex = "#(.*tag-link[-])(.*)(' title.*)#e";
+    $regex = "#(.*tag-link[-])(.*)(' title.*)#";
 
     foreach( $tags as $tag ) {
-    	$tagn[] = preg_replace($regex, "('$1$2 label tag-'.get_tag($2)->slug.'$3')", $tag );
+        $tagn[] = preg_replace_callback($regex, function ($matches) {
+            return $matches[1].$matches[2].' label tag-'.get_tag($matches[2])->slug.$matches[3];
+        }, $tag );
     }
 
     $taglinks = implode('</a>', $tagn);


### PR DESCRIPTION
Simple fix for the tags to work once again!